### PR TITLE
Add player search and filtering endpoints

### DIFF
--- a/COMP303_Assignment4_Manager/src/main/java/com/assignment4/manager/rest/controller/PlayerController.java
+++ b/COMP303_Assignment4_Manager/src/main/java/com/assignment4/manager/rest/controller/PlayerController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import com.assignment4.manager.model.entity.Player;
 import com.assignment4.manager.rest.service.PlayerService;
@@ -50,6 +51,25 @@ public class PlayerController {
 	public Flux<Player> getByTeam(@PathVariable("id") final ObjectId id) {
 		System.out.println("Getting player info for teamId=" + id.toHexString());
 		return players.getByTeam(id);
+	}
+
+	@GetMapping("/search")
+	public Flux<Player> searchByName(
+			@RequestParam(required = false) final String firstName,
+			@RequestParam(required = false) final String lastName) {
+		return players.searchByName(firstName, lastName);
+	}
+
+	@GetMapping("/position/{position}")
+	public Flux<Player> getByPosition(@PathVariable("position") final String position) {
+		return players.getByPosition(position);
+	}
+
+	@GetMapping("/age-range")
+	public Flux<Player> getByAgeRange(
+			@RequestParam final int minAge,
+			@RequestParam final int maxAge) {
+		return players.getByAgeRange(minAge, maxAge);
 	}
 	
 	@PutMapping("{id}")

--- a/COMP303_Assignment4_Manager/src/main/java/com/assignment4/manager/rest/service/PlayerService.java
+++ b/COMP303_Assignment4_Manager/src/main/java/com/assignment4/manager/rest/service/PlayerService.java
@@ -39,6 +39,33 @@ public class PlayerService {
 	public Flux<Player> getByTeam(final ObjectId teamId) {
 		return players.findByTeamId(teamId).switchIfEmpty(Flux.empty());
 	}
+
+	public Flux<Player> searchByName(final String firstName, final String lastName) {
+		return players.findAll()
+			.filter(player -> {
+				boolean matches = true;
+				if (firstName != null && !firstName.isEmpty()) {
+					matches = player.getFirstName().toLowerCase().contains(firstName.toLowerCase());
+				}
+				if (lastName != null && !lastName.isEmpty()) {
+					matches = matches && player.getLastName().toLowerCase().contains(lastName.toLowerCase());
+				}
+				return matches;
+			});
+	}
+
+	public Flux<Player> getByPosition(final String position) {
+		return players.findAll()
+			.filter(player -> player.getPosition().equalsIgnoreCase(position));
+	}
+
+	public Flux<Player> getByAgeRange(final int minAge, final int maxAge) {
+		return players.findAll()
+			.filter(player -> {
+				int age = player.getAge();
+				return age >= minAge && age <= maxAge;
+			});
+	}
 	
 	public Mono<Player> update(final ObjectId playerId, final Player player) {
 		player.setPlayerId(playerId);


### PR DESCRIPTION
## Summary
- Add search by name endpoint (`GET /db/player/search?firstName=&lastName=`)
- Add filter by position endpoint (`GET /db/player/position/{position}`)
- Add age range filtering endpoint (`GET /db/player/age-range?minAge=&maxAge=`)

Closes #1

## Test plan
- [ ] Test search endpoint with various name combinations
- [ ] Test position filter with valid/invalid positions
- [ ] Test age range filter with boundary values