### PR TITLE
Add team statistics endpoint with roster info

### DIFF
--- a/COMP303_Assignment4_Manager/src/main/java/com/assignment4/manager/model/dto/TeamStats.java
+++ b/COMP303_Assignment4_Manager/src/main/java/com/assignment4/manager/model/dto/TeamStats.java
@@ -1,0 +1,20 @@
+package com.assignment4.manager.model.dto;
+
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class TeamStats {
+    private String teamId;
+    private String teamName;
+    private String cityName;
+    private String coachName;
+    private int playerCount;
+    private double averagePlayerAge;
+    private Map<String, Long> positionBreakdown;
+}

--- a/COMP303_Assignment4_Manager/src/main/java/com/assignment4/manager/rest/controller/TeamController.java
+++ b/COMP303_Assignment4_Manager/src/main/java/com/assignment4/manager/rest/controller/TeamController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import com.assignment4.manager.model.dto.TeamStats;
 import com.assignment4.manager.model.entity.Team;
 import com.assignment4.manager.rest.service.TeamService;
 
@@ -44,6 +45,11 @@ public class TeamController {
 	public Mono<Team> getById(@PathVariable("id") final ObjectId id) {
 		System.out.println("Getting team info for id=" + id.toHexString());
 		return teams.getById(id);
+	}
+
+	@GetMapping("{id}/stats")
+	public Mono<TeamStats> getTeamStats(@PathVariable("id") final ObjectId id) {
+		return teams.getTeamStats(id);
 	}
 	
 	@PutMapping("{id}")

--- a/COMP303_Assignment4_Manager/src/main/java/com/assignment4/manager/rest/service/TeamService.java
+++ b/COMP303_Assignment4_Manager/src/main/java/com/assignment4/manager/rest/service/TeamService.java
@@ -3,6 +3,7 @@ package com.assignment4.manager.rest.service;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,7 +12,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import com.assignment4.manager.model.dto.TeamStats;
 import com.assignment4.manager.model.entity.Team;
+import com.assignment4.manager.model.repository.PlayerRepository;
 import com.assignment4.manager.model.repository.TeamRepository;
 
 import lombok.AllArgsConstructor;
@@ -25,6 +28,9 @@ public class TeamService {
 
 	@Autowired
 	private TeamRepository teams;
+
+	@Autowired
+	private PlayerRepository players;
 	
 	public Flux<Team> getAll() {
 		return teams.findAll().switchIfEmpty(Flux.empty());
@@ -34,6 +40,32 @@ public class TeamService {
 	public Mono<Team> getById(final ObjectId teamId) {
 		return teams.findById(teamId)
 		.switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND, "Could not find team with id: " + teamId)));
+	}
+
+	public Mono<TeamStats> getTeamStats(final ObjectId teamId) {
+		return getById(teamId)
+			.flatMap(team -> players.findByTeamId(teamId)
+				.collectList()
+				.map(playerList -> {
+					int count = playerList.size();
+					double avgAge = playerList.stream()
+						.mapToInt(p -> p.getAge())
+						.average()
+						.orElse(0.0);
+					var positions = playerList.stream()
+						.collect(Collectors.groupingBy(
+							p -> p.getPosition(),
+							Collectors.counting()));
+					return TeamStats.builder()
+						.teamId(team.getTeamId())
+						.teamName(team.getTeamName())
+						.cityName(team.getCityName())
+						.coachName(team.getCoachName())
+						.playerCount(count)
+						.averagePlayerAge(avgAge)
+						.positionBreakdown(positions)
+						.build();
+				}));
 	}
 	
 	public Mono<Team> update(final ObjectId teamId, final Team team) {


### PR DESCRIPTION
## Summary
- Create `TeamStats` DTO with player count, average age, and position breakdown
- Add `getTeamStats` method to `TeamService` that aggregates player data per team
- Add `GET /db/team/{id}/stats` endpoint to `TeamController`

Closes #2

## Test plan
- [ ] Test stats endpoint with a team that has players
- [ ] Test stats endpoint with a team that has no players
- [ ] Verify average age calculation is correct