### PR TITLE
Fix unsafe null check in delete operations

### DIFF
--- a/COMP303_Assignment4_Manager/src/main/java/com/assignment4/manager/rest/service/PlayerService.java
+++ b/COMP303_Assignment4_Manager/src/main/java/com/assignment4/manager/rest/service/PlayerService.java
@@ -2,7 +2,6 @@
 package com.assignment4.manager.rest.service;
 
 import java.util.List;
-import java.util.Objects;
 
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -81,13 +80,8 @@ public class PlayerService {
 	}
 	
 	public Mono<Player> delete(final ObjectId id) {
-		final Mono<Player> dbMatch = getById(id);
-		if (Objects.isNull(dbMatch)) {
-			return Mono.empty();
-		}
 		return getById(id)
-				.switchIfEmpty(Mono.empty())
-				.filter(Objects::nonNull)
-				.flatMap(matchToBeDeleted -> players.delete(matchToBeDeleted).then(Mono.just(matchToBeDeleted)));
+			.flatMap(playerToDelete -> players.delete(playerToDelete)
+				.then(Mono.just(playerToDelete)));
 	}
 }

--- a/COMP303_Assignment4_Manager/src/main/java/com/assignment4/manager/rest/service/TeamService.java
+++ b/COMP303_Assignment4_Manager/src/main/java/com/assignment4/manager/rest/service/TeamService.java
@@ -2,7 +2,6 @@
 package com.assignment4.manager.rest.service;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.bson.types.ObjectId;
@@ -82,13 +81,8 @@ public class TeamService {
 	}
 	
 	public Mono<Team> delete(final ObjectId id) {
-		final Mono<Team> dbMatch = getById(id);
-		if (Objects.isNull(dbMatch)) {
-			return Mono.empty();
-		}
 		return getById(id)
-				.switchIfEmpty(Mono.empty())
-				.filter(Objects::nonNull)
-				.flatMap(matchToBeDeleted -> teams.delete(matchToBeDeleted).then(Mono.just(matchToBeDeleted)));
+			.flatMap(teamToDelete -> teams.delete(teamToDelete)
+				.then(Mono.just(teamToDelete)));
 	}
 }


### PR DESCRIPTION
## Summary
- Fix `PlayerService.delete()` — removed `Objects.isNull(dbMatch)` check that never triggered since `Mono` is never null
- Fix `TeamService.delete()` — same issue
- Replace with proper reactive `flatMap` chain that correctly propagates 404 errors

Closes #3

## Test plan
- [ ] Test deleting a valid player/team returns the deleted entity
- [ ] Test deleting a non-existent ID returns 404 error